### PR TITLE
Enable always writing log messages to debug window & other small changes

### DIFF
--- a/WinNUT_V2/WinNUT_GUI/Logger.vb
+++ b/WinNUT_V2/WinNUT_GUI/Logger.vb
@@ -59,10 +59,8 @@
         Debug.WriteLine(FinalMsg)
 #End If
 
-        If Me.WriteLogValue Then
-            If Me.LogLevel >= LvlError Then
-                LogFile.WriteLine(EventTime & " " & Pid & " " & " " & SenderName & " : " & message)
-            End If
+        If Me.WriteLogValue AndAlso Me.LogLevel >= LvlError Then
+            LogFile.WriteLine(FinalMsg)
         End If
         'If LvlError = LogLvl.LOG_NOTICE Then
         If LogToDisplay IsNot Nothing Then

--- a/WinNUT_V2/WinNUT_GUI/Logger.vb
+++ b/WinNUT_V2/WinNUT_GUI/Logger.vb
@@ -1,6 +1,7 @@
 ﻿Public Class Logger
     Private ReadOnly LogFile As New FileLogTraceListener()
     Private ReadOnly TEventCache As New TraceEventCache()
+    ' Enable writing to a log file.
     Public WriteLogValue As Boolean
     Public LogLevelValue As LogLvl
     Private L_CurrentLogData As String
@@ -51,6 +52,13 @@
         Dim Pid = TEventCache.ProcessId
         Dim SenderName = sender.GetType.Name
         Dim EventTime = TEventCache.DateTime.ToLocalTime
+        Dim FinalMsg = EventTime & " " & Pid & " " & " " & SenderName & " : " & message
+
+        ' Always write log messages to the attached debug messages window.
+#If DEBUG Then
+        Debug.WriteLine(FinalMsg)
+#End If
+
         If Me.WriteLogValue Then
             If Me.LogLevel >= LvlError Then
                 LogFile.WriteLine(EventTime & " " & Pid & " " & " " & SenderName & " : " & message)


### PR DESCRIPTION
Here is another small, but potentially important pull request for you. I've modified the Logging logic so log messages will always be written to the debugger messages window when debugging. This will hopefully help with future debugging. I've also made a small tweak to logging code and added a comment for clarity.

I'll hopefully have a bigger pull request for you soon; I'm working on adding some more (clear) messages for when an error occurs when requesting information from the NUT server.