### PR TITLE
Error Handling and Protocol Enhancements

### DIFF
--- a/WinNUT_V2/WinNUT_GUI/My Project/Resources.resx
+++ b/WinNUT_V2/WinNUT_GUI/My Project/Resources.resx
@@ -273,7 +273,7 @@ Cancel to Save Msi and Install Later</value>
     <value>Connection to Nut Host {0}:{1} Established</value>
   </data>
   <data name="Log_Str_03" xml:space="preserve">
-    <value>Connection to Nut Host {0}:{1} Failed</value>
+    <value>Connection to Nut Host {0}:{1} Failed: {2}</value>
   </data>
   <data name="Log_Str_04" xml:space="preserve">
     <value>Automatic Reconnection</value>

--- a/WinNUT_V2/WinNUT_GUI/UPS_Network.vb
+++ b/WinNUT_V2/WinNUT_GUI/UPS_Network.vb
@@ -337,7 +337,7 @@ Public Class UPS_Network
                 End If
                 Me.ConnectionStatus = True
                 Me.Mfr = GetUPSVar("ups.mfr", "Unknown")
-                If Me.Unknown_UPS_Name Then
+                If Me.Unknown_UPS_Name Then 'TODO: Use LIST UPS protocol command to get valid UPSs.
                     Throw New System.Exception("Unknown UPS Name.")
                 End If
                 Me.Model = GetUPSVar("ups.model", "Unknown")

--- a/WinNUT_V2/WinNUT_GUI/UPS_Network.vb
+++ b/WinNUT_V2/WinNUT_GUI/UPS_Network.vb
@@ -45,6 +45,34 @@ Public Class UPS_Network
     Private Invalid_Auth_Data As Boolean = False
     Private Const CosPhi As Double = 0.6
 
+    ' Define possible responses according to NUT protcol v1.2
+    Enum NUTResponse
+        OK
+        ACCESSDENIED
+        UNKNOWNUPS
+        VARNOTSUPPORTED
+        CMDNOTSUPPORTED
+        INVALIDARGUMENT
+        INSTCMDFAILED
+        SETFAILED
+        [READONLY]
+        TOOLONG
+        FEATURENOTSUPPORTED
+        FEATURENOTCONFIGURED
+        ALREADYSSLMODE
+        DRIVERNOTCONNECTED
+        DATASTALE
+        ALREADYLOGGEDIN
+        INVALIDPASSWORD
+        ALREADYSETPASSWORD
+        INVALIDUSERNAME
+        ALREADYSETUSERNAME
+        USERNAMEREQUIRED
+        PASSWORDREQUIRED
+        UNKNOWNCOMMAND
+        INVALIDVALUE
+    End Enum
+
     Public Sub New(ByRef LogFile As Logger)
         Me.Server = ""
         Me.UPSName = ""

--- a/WinNUT_V2/WinNUT_GUI/UPS_Network.vb
+++ b/WinNUT_V2/WinNUT_GUI/UPS_Network.vb
@@ -357,8 +357,8 @@ Public Class UPS_Network
 
     Public Sub Enter_Reconnect_Process(ByVal Excep As Exception, ByVal Message As String)
         Me.ConnectionStatus = False
-        LogFile.LogTracing(Message & Excep.Message, LogLvl.LOG_ERROR, Me, String.Format(WinNUT_Globals.StrLog.Item(AppResxStr.STR_LOG_CON_FAILED) & ": " & Excep.Message, Me.Server, Me.Port))
         If Not Me.Unknown_UPS_Name And Not Me.Invalid_Auth_Data Then
+            LogFile.LogTracing(Message & Excep.Message, LogLvl.LOG_ERROR, Me, String.Format(WinNUT_Globals.StrLog.Item(AppResxStr.STR_LOG_CON_FAILED), Me.Server, Me.Port, Excep.Message))
             Me.LConnect = True
             If Me.AReconnect Then
                 LogFile.LogTracing("Autoreconnect Enable. Run Autoreconnect Process", LogLvl.LOG_DEBUG, Me, WinNUT_Globals.StrLog.Item(AppResxStr.STR_LOG_CON_RETRY))
@@ -492,7 +492,7 @@ Public Class UPS_Network
             Return True
         Catch Excep As Exception
             Me.Disconnect(True)
-            Enter_Reconnect_Process(Excep, "Error When Authentifying ")
+            LogFile.LogTracing(Excep.Message, LogLvl.LOG_ERROR, Me, String.Format(WinNUT_Globals.StrLog.Item(AppResxStr.STR_LOG_CON_FAILED), Me.Server, Me.Port, Excep.Message))
             Return False
         End Try
     End Function


### PR DESCRIPTION
With these changes, my aim is to make the user experience more friendly during the connection and authentication steps. I've also tried to make our jobs as programmers a little easier. A summary of the changes:

- Added an enumeration of possible NUT protocol responses, and a very basic function that will parse a response string into an enum value. More work to come, if it would be helpful.
- Modified a log string to also print out what the error is specifically, to help the user understand what the problem is.
- Modified the username portion of the authentication function to make use of the new responses enum, and handle another case of failure. I also removed the call to reconnect if there's an exception, since I think we'd want the process to hard-fail if there's any issue with authentication. This should hopefully help with error notification spam.

I hope this is beneficial to you!