### PR TITLE
Fix gawindx/WinNUT-Client#100: Send LOGIN message during login

### DIFF
--- a/WinNUT_V2/WinNUT_GUI/UPS_Network.vb
+++ b/WinNUT_V2/WinNUT_GUI/UPS_Network.vb
@@ -419,6 +419,25 @@ Public Class UPS_Network
                 End If
             End If
 
+            SendData = "LOGIN " & Me.UPSName & vbCr
+            Me.WriterStream.WriteLine(SendData)
+            Me.WriterStream.Flush()
+            DataResult = Me.ReaderStream.ReadLine()
+            NUTResult = EnumResponse(DataResult)
+
+            If NUTResult <> NUTResponse.OK Then
+                If NUTResult = NUTResponse.UNKNOWNUPS Then
+                    Me.Unknown_UPS_Name = True
+                    RaiseEvent Unknown_UPS()
+                    Throw New Exception("Unknown UPS Name.")
+                ElseIf NUTResult = NUTResponse.ACCESSDENIED Then
+                    Throw New Exception("Access is denied.")
+                Else
+                    Me.AReconnect = False
+                    Throw New Exception("Unhandled login error: " & DataResult)
+                End If
+            End If
+
             Return True
         Catch Excep As Exception
             Me.Disconnect(True)


### PR DESCRIPTION
I have implemented this as non-optional behaviour, though as mentioned in the issue you might prefer to make this configurable - let me know if so and I can make the change.

I have tested this on my machine against a server running <https://github.com/networkupstools/nut/> and it worked mostly as I'd expect: setting the FSD flag on the server caused WinNUT to start a shutdown, and `upsmon` on the server waited for WinNUT to disconnect before shutting itself down.
The only surprising behaviour was that the FSD shutdown follows the same timing options (grace period, etc.) as a normal shutdown. I originally had WinNUT configured to show the shutdown GUI with a 5 minute timer as soon as the UPS goes onto battery, but this also causes a 5 minute delay during an FSD shutdown. For now I have changed my config to run an immediate shutdown and just decreased the battery/runtime thresholds, so I'm relying on beeping UPS to warn the user instead of the shutdown GUI!